### PR TITLE
:bug: Fix missing Chai type definition. Fixes #53

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "zone.js": "^0.6.23"
   },
   "devDependencies": {
+    "@types/chai": "^3.4.34",
     "@types/isomorphic-fetch": "0.0.30",
     "@types/jasmine": "^2.2.30",
     "@types/node": "^6.0.38",


### PR DESCRIPTION
This commit adds Chain typedefinition as dependency
in package json removing compile time error

Thanks!